### PR TITLE
백준 1253번 문제 풀이

### DIFF
--- a/src/main/java/fossil/study/two_pointer_silver/BOJ1253.java
+++ b/src/main/java/fossil/study/two_pointer_silver/BOJ1253.java
@@ -16,7 +16,7 @@ public class BOJ1253 {
             while(lt < rt){
                 sum = arr[lt] + arr[rt];
 
-                // 두 포인터가 가리키는 곳의 합이 같으면 찾은 경우이다.
+                // 두 포인터가 가리키는 곳의 합이 같은 경
                 if(find == sum){
                     // 또 다른 GOOD을 찾기 위해 포인터 위치 조정
                     if(i == lt) lt++;

--- a/src/main/java/fossil/study/two_pointer_silver/BOJ1337.java
+++ b/src/main/java/fossil/study/two_pointer_silver/BOJ1337.java
@@ -36,11 +36,10 @@ public class BOJ1337 {
         int n = sc.nextInt();
         int[] arr = new int[n];
 
-        for(int i = 0; i < n; i++){
+        for (int i = 0; i < n; i++) {
             arr[i] = sc.nextInt();
         }
 
-        System.out.println(solution(n, arr));
+        // System.out.println(solution(n, arr));
     }
-
 }

--- a/src/main/java/fossil/study/two_pointer_silver/BOJ1337.java
+++ b/src/main/java/fossil/study/two_pointer_silver/BOJ1337.java
@@ -40,6 +40,6 @@ public class BOJ1337 {
             arr[i] = sc.nextInt();
         }
 
-        // System.out.println(solution(n, arr));
+        System.out.println(solution(n, arr));
     }
 }


### PR DESCRIPTION
백준 1253번 문제 풀이입니다.

두 개의 포인터를 두고, 하나의 포인터는 배열의 좌측에서 시작(= 0번 인덱스에서부터 시작)하고, 또 하나의 포인터는 배열의 우측에서(= 마지막에 위치한 인덱스에서 시작)하여 두 포인터가 가리키는 배열의 원소의 합이 같은 곳을 찾는 방식으로 문제를 해결합니다.